### PR TITLE
pc - make Dockerfile consistent across multiple codebases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ WORKDIR /app
 RUN java -version
 RUN curl --version
 
-
 ENV NODE_VERSION=20.17.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -34,20 +33,10 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN . "$NVM_DIR/nvm.sh" && nvm --version
-RUN . "$NVM_DIR/nvm.sh" && nvm install v${NODE_VERSION}
-RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-
-RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
-
 RUN node --version
 RUN npm --version
 
-COPY src /home/app/src
-COPY frontend /home/app/frontend
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
 


### PR DESCRIPTION
In this PR, we make the Dockerfile for this codebase consistent with the other F24 codebases, in that it relies on this setting:

<tt>dokku git:set <i>appname</i> keep-git-dir true</tt>

This setting instructs dokku to keep the `.git` directory after copying the repo into the Docker container.

This allows us to use the `git-commit-id-maven-plugin` which is used in the project code bases.

Note that the `git-commit-id-maven-plugin` has not yet been incorporated into the code base, but making this change will allow it to be in the future.