### PR TITLE
pc - change npm install to npm ci

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
@@ -49,7 +49,7 @@ public class FrontendProxyController {
         String instructions = """
                 <p>Failed to connect to the frontend server...</p>
                 <p>On Dokku, be sure that <code>PRODUCTION</code> is defined.</p>
-                <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm install; npm start</code></p>
+                <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm ci; npm start</code></p>
                 <p>Or, you may click to access: </p>
                 <ul>
                   <li><a href='/swagger-ui/index.html'>/swagger-ui/index.html</a></li>


### PR DESCRIPTION
Change npm install to npm ci in the frontend proxy controller screen that comes up with the frontend is not online.