### PR TITLE
pc - forceRebuild: true on chromatic github action

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -92,6 +92,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
+          forceRebuild: true
     - name: Echo output
       run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"
@@ -369,6 +370,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
+          forceRebuild: true
     - name: Echo output
       run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -44,6 +44,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
+          forceRebuild: true
       - name: Echo output
         run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -85,6 +85,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
+          forceRebuild: true
     - name: Echo output
       run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"


### PR DESCRIPTION
In this PR, we force rebuild of Chromatic.

This may or may not be a good idea to do on all of the workflows; we may end up wanting to do this only on workflow 02.

But for now, let's try it, because we are finding that some students pages are not rebuilding properly without it; the url coming out of the Chromatic Action is undefined because the action is skipped because there's already a cached version of the same build.